### PR TITLE
Avoid error if don't centre and scale.

### DIFF
--- a/gene_expr_heatmap.R
+++ b/gene_expr_heatmap.R
@@ -21,6 +21,8 @@ option_list <- list(
               help="Data is DeTCT data, not RNA-seq [default %default]"),
   make_option("--transform", action="store", type="character", default="rlog",
               help="Transformation to apply to data [default %default]"),
+  make_option("--centre_and_scale", action="store_true", type="logical", default=FALSE,
+              help="Center and scale the counts by row (genes) [default %default]"),
   make_option("--center_and_scale", action="store_true", type="logical", default=FALSE, dest = "centre_and_scale",
               help="Center and scale the counts by row (genes) [default %default]"),
   make_option("--cluster", action="store", type="character", default="none",

--- a/gene_expr_heatmap.R
+++ b/gene_expr_heatmap.R
@@ -21,8 +21,6 @@ option_list <- list(
               help="Data is DeTCT data, not RNA-seq [default %default]"),
   make_option("--transform", action="store", type="character", default="rlog",
               help="Transformation to apply to data [default %default]"),
-  make_option("--centre_and_scale", action="store_true", type="logical", default=FALSE,
-              help="Center and scale the counts by row (genes) [default %default]"),
   make_option("--center_and_scale", action="store_true", type="logical", default=FALSE, dest = "centre_and_scale",
               help="Center and scale the counts by row (genes) [default %default]"),
   make_option("--cluster", action="store", type="character", default="none",
@@ -191,6 +189,8 @@ if (cmd_line_args$options[['transform']] == "rlog") {
 counts <- assay(dds)
 if (cmd_line_args$options[['centre_and_scale']]) {
     counts <- as.data.frame(t( scale( t(counts) ) ))
+} else {
+    counts <- as.data.frame(counts)
 }
 
 # subset data to gene list if provided


### PR DESCRIPTION
So I pointed Louise at your heatmap script after she asked me how to draw one for RNA-seq data. And it worked fine until she turned off the --center_and_scale option (she's looking at homeologues and wants to be able to compare them across rows), at which point she got this error:

```
Error in rownames_to_column(., var = "id") :
  is.data.frame(df) is not TRUE
Calls: %>% -> mutate -> rownames_to_column -> stopifnot
Execution halted
```

And then I had to get involved!

Anyway, this patch fixes the issue, at least in this case. ~~I also removed the duplicate option.~~ And then I added it back because otherwise it doesn't work. ~~Weird.~~ I'm an idiot. I've just spotted you're accounting for centre vs center! My eyes would not see the difference!

Question from Louise: Have you published this anywhere so she can cite you? If not, want an acknowledgment? :)